### PR TITLE
Update JsEditor.tsx

### DIFF
--- a/packages/plugin-code-editor/src/components/JSEditor/JsEditor.tsx
+++ b/packages/plugin-code-editor/src/components/JSEditor/JsEditor.tsx
@@ -250,7 +250,10 @@ export class JsEditor extends PureComponent<JsEditorProps, JsEditorState> {
 
     const pos = monacoEditor.getPosition();
     this.setState({ errorInfo, hasError, code: newCode, errorLocation }, () => {
-      monacoEditor.setPosition(pos);
+      if(hasError) {
+        pos.column += 1;
+        monacoEditor.setPosition(pos);
+      }
 
       // update error decorations
       if (this.lastErrorDecoration) {


### PR DESCRIPTION
接入编辑器=>方法 2.2=> 使用 skeletonCabin.Workbench 方式初始化, 编辑index.js 源码时 光标总是在输入之前